### PR TITLE
Run automated flake8 tests on all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
The owner of the this repo would need to go to https://travis-ci.org/profile and flip the repository switch __on__ to enable free automated flake8 testing of each pull request.

__output:__ 8 undefined names

flake8 testing of https://github.com/HoME-Platform/home-platform on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tests/experiments/panda-physics.py:8:1: F821 undefined name 'base'
base.cam.setPos(10, -30, 20)
^

./tests/experiments/panda-physics.py:9:1: F821 undefined name 'base'
base.cam.lookAt(0, 0, 5)
^

./tests/experiments/panda-physics.py:19:6: F821 undefined name 'render'
np = render.attachNewNode(node)
     ^

./tests/experiments/panda-physics.py:24:9: F821 undefined name 'loader'
model = loader.loadModel('models/box.egg')
        ^

./tests/experiments/panda-physics.py:32:10: F821 undefined name 'render'
    np = render.attachNewNode(node)
         ^

./tests/experiments/panda-physics.py:40:10: F821 undefined name 'globalClock'
    dt = globalClock.getDt()
         ^

./tests/experiments/panda-physics.py:45:1: F821 undefined name 'taskMgr'
taskMgr.add(update, 'update')
^

./tests/experiments/panda-physics.py:46:1: F821 undefined name 'run'
run()
^

8     F821 undefined name 'base'
```