### PR TITLE
Make obj2egg to consider NaN values

### DIFF
--- a/scripts/convert_suncg.sh
+++ b/scripts/convert_suncg.sh
@@ -29,8 +29,8 @@ for obj in ${objects[*]}; do
 	OUTPUT_EGG_FILE="${obj%.obj}.egg"
 	OUTPUT_BAM_FILE="${obj%.obj}.bam"
 
-	if [ -f $OUTPUT_EGG_FILE ]; then
-		echo "Output EGG file ${OUTPUT_EGG_FILE} already found"
+	if [ -f $OUTPUT_BAM_FILE ]; then
+		echo "Output BAM file ${OUTPUT_BAM_FILE} already found"
 		echo "Skipping conversion for OBJ file ${INPUT_OBJ_FILE}"
 		continue
 	fi
@@ -47,7 +47,7 @@ for obj in ${objects[*]}; do
         egg2bam -ps rel -o ${OUTPUT_BAM_FILE} ${OUTPUT_EGG_FILE}
         if ! [ -f $OUTPUT_BAM_FILE ]; then
 		echo "Could not find output file ${OUTPUT_BAM_FILE}. An error probably occured during conversion."
-            	((has_err=1))	
+        ((has_err=1))	
 		((++num_bam_errors))
         fi
     fi

--- a/scripts/obj2egg.py
+++ b/scripts/obj2egg.py
@@ -19,7 +19,7 @@
 from __future__ import print_function
 
 from optparse import OptionParser
-import sys, os
+import sys, os, math
 
 from panda3d.core import Point2D, Point3D, Vec3D, Vec4, GlobPattern, Filename,\
     CSZupRight, CSZupLeft, CSYupRight, CSYupLeft
@@ -360,7 +360,7 @@ class ObjFile:
         # capture the current metadata with vertices
         vdata = floats(v)
         mdata = (self.currentobject, self.currentgroup, self.currentmaterial)
-        vinfo = (vdata, mdata)
+        vinfo = ([0 if math.isnan(vert) else vert for vert in vdata], mdata)
         self.points.append(vinfo)
         return self
 
@@ -603,6 +603,7 @@ def main(argv=None):
 
 if __name__ == "__main__":
     sys.exit(main())
+
 
 
 


### PR DESCRIPTION
Make obj2egg to consider NaN values in .obj files and transform them to zeros.

To reproduce the problem, you can try to load environment with the house_id = "95095cf8001fa8c9eda8e9ff930e6481".
It will raise an exception: "The SUNCG dataset object models need to be convert to Panda3D EGG format!"

After applying the patch run convert_suncg.sh again. It should generate .bam files and fix the problem.